### PR TITLE
feat: add TWZRD Agent Intel remote MCP server

### DIFF
--- a/seed/mcp-servers.json
+++ b/seed/mcp-servers.json
@@ -226,7 +226,7 @@
   {
     "id": "cloudflare-graphql-server",
     "name": "Cloudflare GraphQL",
-    "description": "Get analytics data using Cloudflare’s GraphQL API",
+    "description": "Get analytics data using Cloudflare\u2019s GraphQL API",
     "category": "Cloudflare Service",
     "mcp_url": "https://graphql.mcp.cloudflare.com/sse",
     "authentication_type": "OAuth2",
@@ -620,6 +620,20 @@
     "maintainer_name": "GitMCP",
     "maintainer_url": "https://gitmcp.io",
     "icon_url": null,
+    "is_official": true
+  },
+  {
+    "id": "twzrd-agent-intel",
+    "name": "TWZRD Agent Intel",
+    "description": "Trust + receipt layer for x402 agents on Solana. Free preflight tools score any Solana wallet; paid get_trust_receipt returns signed twzrd.receipt.v5 via HTTP 402 + USDC.",
+    "category": "AI Agents",
+    "mcp_url": "https://intel.twzrd.xyz/mcp",
+    "authentication_type": "x402",
+    "dynamic_client_registration": false,
+    "documentation_url": "https://intel.twzrd.xyz",
+    "maintainer_name": "TWZRD",
+    "maintainer_url": "https://twzrd.xyz",
+    "icon_url": "https://intel.twzrd.xyz/favicon.ico",
     "is_official": true
   }
 ]


### PR DESCRIPTION
## Summary

Adds TWZRD Agent Intel to the remote MCP servers registry.

**Server**: TWZRD Agent Intel  
**MCP URL**: https://intel.twzrd.xyz/mcp  
**Transport**: Streamable HTTP  
**Authentication**: x402 (HTTP 402 + USDC micropayment on Solana — free tools require no auth)

### What it does

TWZRD Agent Intel is a trust and receipt layer for x402 agents on Solana:

- **Free tools**: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt` — open to all callers, no auth required
- **Paid tool**: `get_trust_receipt` — returns a signed `twzrd.receipt.v5` via HTTP 402 micropayment using USDC on Solana (x402 protocol)

### Why it belongs here

This is a remote-only MCP server (streamable-http transport) designed for autonomous agent-to-agent interactions. It is not a local stdio server. This registry is the ideal discovery point for agents that need to verify other agents on Solana.

### References
- modelcontextprotocol/registry: `xyz.twzrd.intel/twzrd-agent-intel` v0.2.1
- PyPI: `twzrd-agent-intel`
- Homepage: https://intel.twzrd.xyz